### PR TITLE
Change sprockets version dependency

### DIFF
--- a/skim.gemspec
+++ b/skim.gemspec
@@ -27,5 +27,5 @@ Sprockets-based asset pipeline.}
   gem.add_development_dependency "execjs"
   gem.add_development_dependency "minitest-reporters"
   gem.add_development_dependency "therubyracer"
-  gem.add_development_dependency "libv8"
+  gem.add_development_dependency "libv8", "~> 3.16.14.0"
 end

--- a/skim.gemspec
+++ b/skim.gemspec
@@ -20,7 +20,7 @@ Sprockets-based asset pipeline.}
   gem.add_dependency "slim", '>= 3.0'
   gem.add_dependency "coffee-script"
   gem.add_dependency "coffee-script-source", ">= 1.2.0"
-  gem.add_dependency "sprockets", ">= 2", "<= 3.0.0.rc1"
+  gem.add_dependency "sprockets", ">= 2"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "pry"

--- a/skim.gemspec
+++ b/skim.gemspec
@@ -20,7 +20,7 @@ Sprockets-based asset pipeline.}
   gem.add_dependency "slim", '>= 3.0'
   gem.add_dependency "coffee-script"
   gem.add_dependency "coffee-script-source", ">= 1.2.0"
-  gem.add_dependency "sprockets", ">= 2"
+  gem.add_dependency "sprockets", ">= 2", "< 4"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "pry"


### PR DESCRIPTION
For now there is available sprockets release candidate version, so we can skip version 3 for this and just leave >= 2 version.